### PR TITLE
Fixing a type in the word 'python' in the text and in the command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ You need <a href="http://bower.io/">bower</a> to resolve the dependencies. In th
 
 ``bower install``
 
-If you have pyhton installed, you can start serving the project via:
+If you have python installed, you can start serving the project via:
 
-``pyhton -m SimpleHTTPServer``
+``python -m SimpleHTTPServer``
 
 else use any other webserver to start serving the project directory or just open the index.html in your browser (which might result in errors dependendent on the browser)


### PR DESCRIPTION
I believe it's also interesting to mention that we should access it at localhost:8000, and not 0.0.0.0:8000 as the webserver suggests.
